### PR TITLE
Change is_streaming:bool to stream_samples:u8

### DIFF
--- a/services/_base.md
+++ b/services/_base.md
@@ -79,9 +79,10 @@ The primary value of actuator (eg. servo pulse length, or motor duty cycle).
 
 Limit the power drawn by the service, in mA.
 
-    rw is_streaming: bool @ 0x03
+    rw stream_samples: u8 @ 0x03
 
-Enables/disables broadcast streaming
+Asks device to stream a given number of samples
+(clients will typically write `255` to this register every second or so, while streaming is required).
 
     rw streaming_interval = 100: u32 ms @ 0x04
 

--- a/services/_sensor.md
+++ b/services/_sensor.md
@@ -6,9 +6,10 @@ Base class for sensors.
 
 ## Registers
 
-    rw is_streaming: bool @ is_streaming
+    rw stream_samples: u8 @ stream_samples
 
-Enables/disables broadcast streaming
+Asks device to stream a given number of samples
+(clients will typically write `255` to this register every second or so, while streaming is required).
 
     rw streaming_interval = 100: u32 ms {typical_min = 1, typical_max = 60000} @ streaming_interval
 

--- a/services/button.md
+++ b/services/button.md
@@ -6,7 +6,7 @@
 A simple push-button.
 
 Note: this service will stream readings while the button is pressed and shortly after it's released, even
-when `is_streaming == 0`. TODO remove this?
+when `stream_samples == 0`. TODO remove this?
 
 ## Registers
 

--- a/spec/service-spec-language.mdx
+++ b/spec/service-spec-language.mdx
@@ -229,14 +229,14 @@ Emitted when button goes from inactive (`pressed == 0`) to active.
 Emitted when button goes from active (`pressed == 1`) to inactive.
 ```
 
-All registers from the `_sensor.md` will be included (meaning `is_streaming` and `streaming_interval`).
+All registers from the `_sensor.md` will be included (meaning `stream_samples` and `streaming_interval`).
 Similarly, all commands and events would be included (but there are none).
 
 The address of `pressed` register is specified as `@ reading`, meaning the
 address of the `reading` register in `_base.md`.
 Services cannot extend `_base.md`, because it includes a large number of packets that are
 never all present at the same time in a regular service.
-However, the names of these packets can be used in places of addresses.
+However, the names of these packets can be used in place of addresses.
 In fact, this is the only way to refer to the addresses in the system range:
 if the example used `@ 0x101` instead of `@ reading`, the jdspectool would
 generate an error.


### PR DESCRIPTION
@pelikhan if I change this in JM-modules, can you update jacdac-ts to re-send `stream_samples := 255` for everything that needs streaming every `bus.on(SELF_ANNOUNCE, () => { ... })` or so? It should also work with current modules.