### PR TITLE
checking ranges

### DIFF
--- a/dist/c/_system.h
+++ b/dist/c/_system.h
@@ -94,7 +94,7 @@ typedef struct jd_system_event_report {
  * state. This report is typically not queried, when a device has an error, it will typically
  * add this report in frame along with the anounce packet.
  */
-#define JD_REG_STATUS_CODE 0x7
+#define JD_REG_STATUS_CODE 0x103
 typedef struct jd_system_status_code {
     uint16_t code;
     uint16_t vendor_code;

--- a/dist/c/prototest.h
+++ b/dist/c/prototest.h
@@ -7,52 +7,52 @@
 /**
  * Read-write bool (uint8_t). A read write bool register.
  */
-#define JD_PROTO_TEST_REG_RW_BOOL 0x181
+#define JD_PROTO_TEST_REG_RW_BOOL 0x81
 
 /**
  * Read-only bool (uint8_t). A read only bool register. Mirrors rw_bool.
  */
-#define JD_PROTO_TEST_REG_RO_BOOL 0x182
+#define JD_PROTO_TEST_REG_RO_BOOL 0x181
 
 /**
  * Read-write uint32_t. A read write u32 register.
  */
-#define JD_PROTO_TEST_REG_RW_U32 0x190
+#define JD_PROTO_TEST_REG_RW_U32 0x82
 
 /**
  * Read-only uint32_t. A read only u32 register.. Mirrors rw_u32.
  */
-#define JD_PROTO_TEST_REG_RO_U32 0x191
+#define JD_PROTO_TEST_REG_RO_U32 0x182
 
 /**
  * Read-write int32_t. A read write i32 register.
  */
-#define JD_PROTO_TEST_REG_RW_I32 0x192
+#define JD_PROTO_TEST_REG_RW_I32 0x83
 
 /**
  * Read-only int32_t. A read only i32 register.. Mirrors rw_i32.
  */
-#define JD_PROTO_TEST_REG_RO_I32 0x193
+#define JD_PROTO_TEST_REG_RO_I32 0x183
 
 /**
  * Read-write string (bytes). A read write string register.
  */
-#define JD_PROTO_TEST_REG_RW_STRING 0x1a0
+#define JD_PROTO_TEST_REG_RW_STRING 0x84
 
 /**
  * Read-only string (bytes). A read only string register. Mirrors rw_string.
  */
-#define JD_PROTO_TEST_REG_RO_STRING 0x1a1
+#define JD_PROTO_TEST_REG_RO_STRING 0x184
 
 /**
  * Read-write bytes. A read write string register.
  */
-#define JD_PROTO_TEST_REG_RW_BYTES 0x1b0
+#define JD_PROTO_TEST_REG_RW_BYTES 0x85
 
 /**
  * Read-only bytes. A read only string register. Mirrors ro_bytes.
  */
-#define JD_PROTO_TEST_REG_RO_BYTES 0x1b1
+#define JD_PROTO_TEST_REG_RO_BYTES 0x185
 
 /**
  * Argument: bool bool (uint8_t). An event raised when rw_bool is modified

--- a/dist/services.json
+++ b/dist/services.json
@@ -10,7 +10,7 @@
       "short": "This file describes common register and command codes.\nThese are defined in ranges separate from the per-service ones.\nNo service actually derives from this file, but services can include packets\ndefined here.\nTheir code is listed as say `@ intensity` and not `@ 0x01` (the spectool enforces that).",
       "commands": "Command codes are subdivided as follows:\n* Commands `0x000-0x07f` - common to all services\n* Commands `0x080-0xeff` - defined per-service\n* Commands `0xf00-0xfff` - reserved for implementation\n\nCommands follow.",
       "registers": "Register codes are subdivided as follows:\n* Registers `0x001-0x07f` - r/w common to all services\n* Registers `0x080-0x0ff` - r/w defined per-service\n* Registers `0x100-0x17f` - r/o common to all services\n* Registers `0x180-0x1ff` - r/o defined per-service\n* Registers `0x200-0xeff` - custom, defined per-service\n* Registers `0xf00-0xfff` - reserved for implementation, should not be seen on the wire\n\nThe types listed are typical. Check spec for particular service for exact type,\nand a service-specific name for a register (eg. `value` could be `pulse_length`).\nAll registers default to `0` unless otherwise indicated.",
-      "events": "Command codes are subdivided as follows:\n* Commands `0x000-0x07f` - common to all services\n* Commands `0x080-0xeff` - defined per-service\n* Commands `0xf00-0xfff` - reserved for implementation"
+      "events": "Events codes are subdivided as follows:\n* Events `0x000-0x07f` - common to all services\n* Events `0x080-0xeff` - defined per-service\n* Events `0xf00-0xfff` - reserved for implementation"
     },
     "classIdentifier": 536870897,
     "enums": {},
@@ -228,7 +228,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -272,7 +272,7 @@
         "fields": []
       }
     ],
-    "source": "# Common registers and commands\n\n    camel: system\n\nThis file describes common register and command codes.\nThese are defined in ranges separate from the per-service ones.\nNo service actually derives from this file, but services can include packets\ndefined here.\nTheir code is listed as say `@ intensity` and not `@ 0x01` (the spectool enforces that).\n\n## Commands\n\nCommand codes are subdivided as follows:\n* Commands `0x000-0x07f` - common to all services\n* Commands `0x080-0xeff` - defined per-service\n* Commands `0xf00-0xfff` - reserved for implementation\n\nCommands follow.\n\n    command announce @ 0x00 { }\n    report { ... }\n\nEnumeration data for control service; service-specific advertisement data otherwise.\nControl broadcasts it automatically every 500ms, but other service have to be queried to provide it.\n\n    command get_register @ 0x1000 {}\n    report { ... }\n\nRegisters number `N` is fetched by issuing command `0x1000 | N`.\nThe report format is the same as the format of the register.\n\n    command set_register @ 0x2000 { ... }\n\nRegisters number `N` is set by issuing command `0x2000 | N`, with the format\nthe same as the format of the register.\n\n    report event @ 0x01 {\n        event_id: u32\n        event_argument: u32\n    }\n\nEvent from sensor or a broadcast service. \n\n    command calibrate @ 0x02 { }\n    report { }\n\nRequest to calibrate a sensor. The report indicates the calibration is done.\n\n## Registers\n\nRegister codes are subdivided as follows:\n* Registers `0x001-0x07f` - r/w common to all services\n* Registers `0x080-0x0ff` - r/w defined per-service\n* Registers `0x100-0x17f` - r/o common to all services\n* Registers `0x180-0x1ff` - r/o defined per-service\n* Registers `0x200-0xeff` - custom, defined per-service\n* Registers `0xf00-0xfff` - reserved for implementation, should not be seen on the wire\n\nThe types listed are typical. Check spec for particular service for exact type,\nand a service-specific name for a register (eg. `value` could be `pulse_length`).\nAll registers default to `0` unless otherwise indicated.\n\n    rw intensity: u32 @ 0x01\n\nThis is either binary on/off (0 or non-zero), or can be gradual (eg. brightness of an RGB LED strip).\n\n    rw value: i32 @ 0x02\n\nThe primary value of actuator (eg. servo pulse length, or motor duty cycle).\n\n    rw max_power = 500: u16 mA {typical_max = 500} @ 0x07\n\nLimit the power drawn by the service, in mA.\n\n    rw streaming_samples: u8 @ 0x03\n\nAsks device to stream a given number of samples\n(clients will typically write `255` to this register every second or so, while streaming is required).\n\n    rw streaming_interval = 100: u32 ms @ 0x04\n\nPeriod between packets of data when streaming in milliseconds.\n\n    ro reading: i32 @ 0x101\n\nRead-only value of the sensor, also reported in streaming.\n\n    rw low_threshold: i32 @ 0x05\n    rw high_threshold: i32 @ 0x06\n\nThresholds for event generation for event generation for analog sensors.\n\n    ro status_code @ 0x7 {\n        code: u16\n        vendor_code: u16\n    }\n\nReports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.\n\n    const streaming_preferred_interval: u32 ms @ 0x102\n\nPreferred default streaming interval for sensor in milliseconds.\n\n## Events\n\nCommand codes are subdivided as follows:\n* Commands `0x000-0x07f` - common to all services\n* Commands `0x080-0xeff` - defined per-service\n* Commands `0xf00-0xfff` - reserved for implementation\n\n    event change @ 0x02 { }\n\nEmit notifying that the internal state of the service changed."
+    "source": "# Common registers and commands\n\n    camel: system\n\nThis file describes common register and command codes.\nThese are defined in ranges separate from the per-service ones.\nNo service actually derives from this file, but services can include packets\ndefined here.\nTheir code is listed as say `@ intensity` and not `@ 0x01` (the spectool enforces that).\n\n## Commands\n\nCommand codes are subdivided as follows:\n* Commands `0x000-0x07f` - common to all services\n* Commands `0x080-0xeff` - defined per-service\n* Commands `0xf00-0xfff` - reserved for implementation\n\nCommands follow.\n\n    command announce @ 0x00 { }\n    report { ... }\n\nEnumeration data for control service; service-specific advertisement data otherwise.\nControl broadcasts it automatically every 500ms, but other service have to be queried to provide it.\n\n    command get_register @ 0x1000 {}\n    report { ... }\n\nRegisters number `N` is fetched by issuing command `0x1000 | N`.\nThe report format is the same as the format of the register.\n\n    command set_register @ 0x2000 { ... }\n\nRegisters number `N` is set by issuing command `0x2000 | N`, with the format\nthe same as the format of the register.\n\n    report event @ 0x01 {\n        event_id: u32\n        event_argument: u32\n    }\n\nEvent from sensor or a broadcast service. \n\n    command calibrate @ 0x02 { }\n    report { }\n\nRequest to calibrate a sensor. The report indicates the calibration is done.\n\n## Registers\n\nRegister codes are subdivided as follows:\n* Registers `0x001-0x07f` - r/w common to all services\n* Registers `0x080-0x0ff` - r/w defined per-service\n* Registers `0x100-0x17f` - r/o common to all services\n* Registers `0x180-0x1ff` - r/o defined per-service\n* Registers `0x200-0xeff` - custom, defined per-service\n* Registers `0xf00-0xfff` - reserved for implementation, should not be seen on the wire\n\nThe types listed are typical. Check spec for particular service for exact type,\nand a service-specific name for a register (eg. `value` could be `pulse_length`).\nAll registers default to `0` unless otherwise indicated.\n\n    rw intensity: u32 @ 0x01\n\nThis is either binary on/off (0 or non-zero), or can be gradual (eg. brightness of an RGB LED strip).\n\n    rw value: i32 @ 0x02\n\nThe primary value of actuator (eg. servo pulse length, or motor duty cycle).\n\n    rw max_power = 500: u16 mA {typical_max = 500} @ 0x07\n\nLimit the power drawn by the service, in mA.\n\n    rw streaming_samples: u8 @ 0x03\n\nAsks device to stream a given number of samples\n(clients will typically write `255` to this register every second or so, while streaming is required).\n\n    rw streaming_interval = 100: u32 ms @ 0x04\n\nPeriod between packets of data when streaming in milliseconds.\n\n    ro reading: i32 @ 0x101\n\nRead-only value of the sensor, also reported in streaming.\n\n    rw low_threshold: i32 @ 0x05\n    rw high_threshold: i32 @ 0x06\n\nThresholds for event generation for event generation for analog sensors.\n\n    ro status_code @ 0x103 {\n        code: u16\n        vendor_code: u16\n    }\n\nReports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.\n\n    const streaming_preferred_interval: u32 ms @ 0x102\n\nPreferred default streaming interval for sensor in milliseconds.\n\n## Events\n\nEvents codes are subdivided as follows:\n* Events `0x000-0x07f` - common to all services\n* Events `0x080-0xeff` - defined per-service\n* Events `0xf00-0xfff` - reserved for implementation\n\n    event change @ 0x02 { }\n\nEmit notifying that the internal state of the service changed."
   },
   {
     "name": "Base service",
@@ -290,7 +290,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -333,7 +333,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -436,7 +436,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -668,7 +668,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -860,7 +860,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -1097,7 +1097,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -1245,7 +1245,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -1338,7 +1338,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -1414,7 +1414,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -1682,7 +1682,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -1906,7 +1906,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -2029,7 +2029,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -2627,7 +2627,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -2707,7 +2707,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -2838,7 +2838,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -2970,7 +2970,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -3127,7 +3127,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -3247,7 +3247,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -3340,7 +3340,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -3630,7 +3630,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -3729,7 +3729,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -3849,7 +3849,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -4049,7 +4049,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -4251,7 +4251,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -4277,7 +4277,7 @@
       {
         "kind": "rw",
         "name": "rw_bool",
-        "identifier": 385,
+        "identifier": 129,
         "description": "A read write bool register.",
         "fields": [
           {
@@ -4292,7 +4292,7 @@
       {
         "kind": "ro",
         "name": "ro_bool",
-        "identifier": 386,
+        "identifier": 385,
         "description": "A read only bool register. Mirrors rw_bool.",
         "fields": [
           {
@@ -4307,7 +4307,7 @@
       {
         "kind": "rw",
         "name": "rw_u32",
-        "identifier": 400,
+        "identifier": 130,
         "description": "A read write u32 register.",
         "fields": [
           {
@@ -4323,7 +4323,7 @@
       {
         "kind": "ro",
         "name": "ro_u32",
-        "identifier": 401,
+        "identifier": 386,
         "description": "A read only u32 register.. Mirrors rw_u32.",
         "fields": [
           {
@@ -4339,7 +4339,7 @@
       {
         "kind": "rw",
         "name": "rw_i32",
-        "identifier": 402,
+        "identifier": 131,
         "description": "A read write i32 register.",
         "fields": [
           {
@@ -4355,7 +4355,7 @@
       {
         "kind": "ro",
         "name": "ro_i32",
-        "identifier": 403,
+        "identifier": 387,
         "description": "A read only i32 register.. Mirrors rw_i32.",
         "fields": [
           {
@@ -4371,7 +4371,7 @@
       {
         "kind": "rw",
         "name": "rw_string",
-        "identifier": 416,
+        "identifier": 132,
         "description": "A read write string register.",
         "fields": [
           {
@@ -4386,7 +4386,7 @@
       {
         "kind": "ro",
         "name": "ro_string",
-        "identifier": 417,
+        "identifier": 388,
         "description": "A read only string register. Mirrors rw_string.",
         "fields": [
           {
@@ -4401,7 +4401,7 @@
       {
         "kind": "rw",
         "name": "rw_bytes",
-        "identifier": 432,
+        "identifier": 133,
         "description": "A read write string register.",
         "fields": [
           {
@@ -4417,8 +4417,8 @@
       {
         "kind": "ro",
         "name": "ro_bytes",
-        "identifier": 433,
-        "description": "A read only string register. Mirrors ro_bytes.\n\n\nA read only u8/u16/u32 register.",
+        "identifier": 389,
+        "description": "A read only string register. Mirrors ro_bytes.",
         "fields": [
           {
             "name": "_",
@@ -4525,7 +4525,7 @@
         "packFormat": "i32"
       }
     ],
-    "source": "# Protocol Test\n\n    identifier: 0x16c7466a\n    camel: protoTest\n\nThis is test service to validate the protocol packet transmissions.\n\n### Test procedure\n\nFor each ``rw`` registers, set a random value ``x``\n  * read ``rw`` and check value is equal to ``x``\n  * read ``ro`` and check value is equal to ``x``\n  * listen to ``e`` event and check that data is equal to ``x``\n  * call ``c`` command with new random value ``y``\n  * read ``rw`` and check value is equal to ``y``\n  * do all the above steps with acks\n  \n## Registers\n\nEvery ``rw`` register has a corresponding ``ro`` regisrer\nand a corresponding ``set_...`` command to also set the value.\n\n    rw rw_bool : bool @ 0x181\n\nA read write bool register.\n\n    ro ro_bool : bool @ 0x182\n\nA read only bool register. Mirrors rw_bool.\n\n    rw rw_u32 : u32 @ 0x190\n\nA read write u32 register.\n\n    ro ro_u32 : u32 @ 0x191\n\nA read only u32 register.. Mirrors rw_u32.\n\n    rw rw_i32 : i32 @ 0x192\n\nA read write i32 register.\n\n    ro ro_i32 : i32 @ 0x193\n\nA read only i32 register.. Mirrors rw_i32.\n\n    rw rw_string : string @ 0x1a0\n\nA read write string register.\n\n    ro ro_string : string @ 0x1a1\n\nA read only string register. Mirrors rw_string.\n\n    rw rw_bytes : bytes @ 0x1b0\n\nA read write string register.\n\n    ro ro_bytes : bytes @ 0x1b1\n\nA read only string register. Mirrors ro_bytes.\n\n\nA read only u8/u16/u32 register.\n\n## Events\n\n    event e_bool @ 0x180 { \n        bool: bool \n    }\n\nAn event raised when rw_bool is modified\n\n    event e_u32 @ 0x190 { \n        u32: u32 \n    }\n\nAn event raised when rw_u32 is modified\n\n    event e_i32 @ 0x192 { \n        i32: i32 \n    }\n\nAn event raised when rw_i32 is modified\n\n## Commands\n\n    command c_bool @ 0x80 {\n        bool: bool\n    }\n\nA command to set rw_bool. Returns the value.\n\n    command c_u32 @ 0x81 {\n        u32: u32\n    }\n\nA command to set rw_u32. Returns the value.\n\n    command c_i32 @ 0x82 {\n        i32: i32\n    }\n\nA command to set rw_i32. Returns the value.\n"
+    "source": "# Protocol Test\n\n    identifier: 0x16c7466a\n    camel: protoTest\n\nThis is test service to validate the protocol packet transmissions.\n\n### Test procedure\n\nFor each ``rw`` registers, set a random value ``x``\n  * read ``rw`` and check value is equal to ``x``\n  * read ``ro`` and check value is equal to ``x``\n  * listen to ``e`` event and check that data is equal to ``x``\n  * call ``c`` command with new random value ``y``\n  * read ``rw`` and check value is equal to ``y``\n  * do all the above steps with acks\n  \n## Registers\n\nEvery ``rw`` register has a corresponding ``ro`` regisrer\nand a corresponding ``set_...`` command to also set the value.\n\n    rw rw_bool : bool @ 0x081\n\nA read write bool register.\n\n    ro ro_bool : bool @ 0x181\n\nA read only bool register. Mirrors rw_bool.\n\n    rw rw_u32 : u32 @ 0x082\n\nA read write u32 register.\n\n    ro ro_u32 : u32 @ 0x182\n\nA read only u32 register.. Mirrors rw_u32.\n\n    rw rw_i32 : i32 @ 0x083\n\nA read write i32 register.\n\n    ro ro_i32 : i32 @ 0x183\n\nA read only i32 register.. Mirrors rw_i32.\n\n    rw rw_string : string @ 0x084\n\nA read write string register.\n\n    ro ro_string : string @ 0x184\n\nA read only string register. Mirrors rw_string.\n\n    rw rw_bytes : bytes @ 0x085\n\nA read write string register.\n\n    ro ro_bytes : bytes @ 0x185\n\nA read only string register. Mirrors ro_bytes.\n\n## Events\n\n    event e_bool @ 0x180 { \n        bool: bool \n    }\n\nAn event raised when rw_bool is modified\n\n    event e_u32 @ 0x190 { \n        u32: u32 \n    }\n\nAn event raised when rw_u32 is modified\n\n    event e_i32 @ 0x192 { \n        i32: i32 \n    }\n\nAn event raised when rw_i32 is modified\n\n## Commands\n\n    command c_bool @ 0x80 {\n        bool: bool\n    }\n\nA command to set rw_bool. Returns the value.\n\n    command c_u32 @ 0x81 {\n        u32: u32\n    }\n\nA command to set rw_u32. Returns the value.\n\n    command c_i32 @ 0x82 {\n        i32: i32\n    }\n\nA command to set rw_i32. Returns the value.\n"
   },
   {
     "name": "PWM Light",
@@ -4546,7 +4546,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -4700,7 +4700,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -4917,7 +4917,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -5055,7 +5055,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -5135,7 +5135,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -5334,7 +5334,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -5466,7 +5466,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -5619,7 +5619,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {
@@ -5759,7 +5759,7 @@
       {
         "kind": "ro",
         "name": "status_code",
-        "identifier": 7,
+        "identifier": 259,
         "description": "Reports the current state or error status of the device. ``code`` is a standardized value from \nthe JACDAC error codes. ``vendor_code`` is any vendor specific error code describing the device\nstate. This report is typically not queried, when a device has an error, it will typically\nadd this report in frame along with the anounce packet.",
         "fields": [
           {

--- a/dist/specconstants.sts
+++ b/dist/specconstants.sts
@@ -97,7 +97,7 @@ namespace jacdac {
          * const [code, vendorCode] = jdunpack<[number, number]>(buf, "u16 u16")
          * ```
          */
-        StatusCode = 0x7,
+        StatusCode = 0x103,
 
         /**
          * Constant ms uint32_t. Preferred default streaming interval for sensor in milliseconds.
@@ -127,7 +127,7 @@ namespace jacdac {
          * const [code, vendorCode] = jdunpack<[number, number]>(buf, "u16 u16")
          * ```
          */
-        StatusCode = 0x7,
+        StatusCode = 0x103,
     }
 
 }
@@ -1344,52 +1344,52 @@ namespace jacdac {
         /**
          * Read-write bool (uint8_t). A read write bool register.
          */
-        RwBool = 0x181,
+        RwBool = 0x81,
 
         /**
          * Read-only bool (uint8_t). A read only bool register. Mirrors rw_bool.
          */
-        RoBool = 0x182,
+        RoBool = 0x181,
 
         /**
          * Read-write uint32_t. A read write u32 register.
          */
-        RwU32 = 0x190,
+        RwU32 = 0x82,
 
         /**
          * Read-only uint32_t. A read only u32 register.. Mirrors rw_u32.
          */
-        RoU32 = 0x191,
+        RoU32 = 0x182,
 
         /**
          * Read-write int32_t. A read write i32 register.
          */
-        RwI32 = 0x192,
+        RwI32 = 0x83,
 
         /**
          * Read-only int32_t. A read only i32 register.. Mirrors rw_i32.
          */
-        RoI32 = 0x193,
+        RoI32 = 0x183,
 
         /**
          * Read-write string (bytes). A read write string register.
          */
-        RwString = 0x1a0,
+        RwString = 0x84,
 
         /**
          * Read-only string (bytes). A read only string register. Mirrors rw_string.
          */
-        RoString = 0x1a1,
+        RoString = 0x184,
 
         /**
          * Read-write bytes. A read write string register.
          */
-        RwBytes = 0x1b0,
+        RwBytes = 0x85,
 
         /**
          * Read-only bytes. A read only string register. Mirrors ro_bytes.
          */
-        RoBytes = 0x1b1,
+        RoBytes = 0x185,
     }
 
     export const enum ProtoTestEvent {

--- a/dist/specconstants.ts
+++ b/dist/specconstants.ts
@@ -96,7 +96,7 @@ export enum SystemReg {
      * const [code, vendorCode] = jdunpack<[number, number]>(buf, "u16 u16")
      * ```
      */
-    StatusCode = 0x7,
+    StatusCode = 0x103,
 
     /**
      * Constant ms uint32_t. Preferred default streaming interval for sensor in milliseconds.
@@ -124,7 +124,7 @@ export enum BaseReg {
      * const [code, vendorCode] = jdunpack<[number, number]>(buf, "u16 u16")
      * ```
      */
-    StatusCode = 0x7,
+    StatusCode = 0x103,
 }
 
 // Service: Sensor
@@ -1295,52 +1295,52 @@ export enum ProtoTestReg {
     /**
      * Read-write bool (uint8_t). A read write bool register.
      */
-    RwBool = 0x181,
+    RwBool = 0x81,
 
     /**
      * Read-only bool (uint8_t). A read only bool register. Mirrors rw_bool.
      */
-    RoBool = 0x182,
+    RoBool = 0x181,
 
     /**
      * Read-write uint32_t. A read write u32 register.
      */
-    RwU32 = 0x190,
+    RwU32 = 0x82,
 
     /**
      * Read-only uint32_t. A read only u32 register.. Mirrors rw_u32.
      */
-    RoU32 = 0x191,
+    RoU32 = 0x182,
 
     /**
      * Read-write int32_t. A read write i32 register.
      */
-    RwI32 = 0x192,
+    RwI32 = 0x83,
 
     /**
      * Read-only int32_t. A read only i32 register.. Mirrors rw_i32.
      */
-    RoI32 = 0x193,
+    RoI32 = 0x183,
 
     /**
      * Read-write string (bytes). A read write string register.
      */
-    RwString = 0x1a0,
+    RwString = 0x84,
 
     /**
      * Read-only string (bytes). A read only string register. Mirrors rw_string.
      */
-    RoString = 0x1a1,
+    RoString = 0x184,
 
     /**
      * Read-write bytes. A read write string register.
      */
-    RwBytes = 0x1b0,
+    RwBytes = 0x85,
 
     /**
      * Read-only bytes. A read only string register. Mirrors ro_bytes.
      */
-    RoBytes = 0x1b1,
+    RoBytes = 0x185,
 }
 
 export enum ProtoTestEvent {

--- a/services/_system.md
+++ b/services/_system.md
@@ -90,7 +90,7 @@ Read-only value of the sensor, also reported in streaming.
 
 Thresholds for event generation for event generation for analog sensors.
 
-    ro status_code @ 0x7 {
+    ro status_code @ 0x103 {
         code: u16
         vendor_code: u16
     }
@@ -106,10 +106,10 @@ Preferred default streaming interval for sensor in milliseconds.
 
 ## Events
 
-Command codes are subdivided as follows:
-* Commands `0x000-0x07f` - common to all services
-* Commands `0x080-0xeff` - defined per-service
-* Commands `0xf00-0xfff` - reserved for implementation
+Events codes are subdivided as follows:
+* Events `0x000-0x07f` - common to all services
+* Events `0x080-0xeff` - defined per-service
+* Events `0xf00-0xfff` - reserved for implementation
 
     event change @ 0x02 { }
 

--- a/services/prototest.md
+++ b/services/prototest.md
@@ -20,48 +20,45 @@ For each ``rw`` registers, set a random value ``x``
 Every ``rw`` register has a corresponding ``ro`` regisrer
 and a corresponding ``set_...`` command to also set the value.
 
-    rw rw_bool : bool @ 0x181
+    rw rw_bool : bool @ 0x081
 
 A read write bool register.
 
-    ro ro_bool : bool @ 0x182
+    ro ro_bool : bool @ 0x181
 
 A read only bool register. Mirrors rw_bool.
 
-    rw rw_u32 : u32 @ 0x190
+    rw rw_u32 : u32 @ 0x082
 
 A read write u32 register.
 
-    ro ro_u32 : u32 @ 0x191
+    ro ro_u32 : u32 @ 0x182
 
 A read only u32 register.. Mirrors rw_u32.
 
-    rw rw_i32 : i32 @ 0x192
+    rw rw_i32 : i32 @ 0x083
 
 A read write i32 register.
 
-    ro ro_i32 : i32 @ 0x193
+    ro ro_i32 : i32 @ 0x183
 
 A read only i32 register.. Mirrors rw_i32.
 
-    rw rw_string : string @ 0x1a0
+    rw rw_string : string @ 0x084
 
 A read write string register.
 
-    ro ro_string : string @ 0x1a1
+    ro ro_string : string @ 0x184
 
 A read only string register. Mirrors rw_string.
 
-    rw rw_bytes : bytes @ 0x1b0
+    rw rw_bytes : bytes @ 0x085
 
 A read write string register.
 
-    ro ro_bytes : bytes @ 0x1b1
+    ro ro_bytes : bytes @ 0x185
 
 A read only string register. Mirrors ro_bytes.
-
-
-A read only u8/u16/u32 register.
 
 ## Events
 

--- a/spectool/jdspec.ts
+++ b/spectool/jdspec.ts
@@ -128,14 +128,14 @@ export function resolveUnit(unit: string) {
 }
 
 
-    /* check ranges, see system.md
-    Registers `0x001-0x07f` - r/w common to all services
-    Registers `0x080-0x0ff` - r/w defined per-service
-    Registers `0x100-0x17f` - r/o common to all services
-    Registers `0x180-0x1ff` - r/o defined per-service
-    Registers `0x200-0xeff` - custom, defined per-service
-    Registers `0xf00-0xfff` - reserved for implementation, should not be seen on the wire
-    */
+/* check ranges, see system.md
+Registers `0x001-0x07f` - r/w common to all services
+Registers `0x080-0x0ff` - r/w defined per-service
+Registers `0x100-0x17f` - r/o common to all services
+Registers `0x180-0x1ff` - r/o defined per-service
+Registers `0x200-0xeff` - custom, defined per-service
+Registers `0xf00-0xfff` - reserved for implementation, should not be seen on the wire
+*/
 const identifierRanges: { [index: string]: [number, number][] } = {
     "rw": [
         [0x001, 0x07f],
@@ -339,7 +339,9 @@ export function parseServiceSpecificationMarkdownToJSON(filecontent: string, inc
 
         const pid = packetInfo.identifier;
         const ranges = identifierRanges[packetInfo.kind];
-        if (ranges && !ranges.some(range => range[0] <= pid && pid <= range[1]))
+        if (packetInfo.name != "set_register"
+            && packetInfo.name != "get_register"
+            && ranges && !ranges.some(range => range[0] <= pid && pid <= range[1]))
             error(`${packetInfo.name} identifier 0x${pid.toString(16)} out of range, expected in ${ranges.map(range => `[${range.map(r => `0x${r.toString(16)}`).join(', ')}]`).join(', ')}`)
 
         packetInfo = null

--- a/spectool/jdspec.ts
+++ b/spectool/jdspec.ts
@@ -127,6 +127,40 @@ export function resolveUnit(unit: string) {
     return undefined;
 }
 
+
+    /* check ranges, see system.md
+    Registers `0x001-0x07f` - r/w common to all services
+    Registers `0x080-0x0ff` - r/w defined per-service
+    Registers `0x100-0x17f` - r/o common to all services
+    Registers `0x180-0x1ff` - r/o defined per-service
+    Registers `0x200-0xeff` - custom, defined per-service
+    Registers `0xf00-0xfff` - reserved for implementation, should not be seen on the wire
+    */
+const identifierRanges: { [index: string]: [number, number][] } = {
+    "rw": [
+        [0x001, 0x07f],
+        [0x080, 0x0ff],
+        [0x200, 0xeff], // custom
+        [0xf00, 0xfff], // impl
+    ],
+    "ro": [
+        [0x100, 0x17f],
+        [0x180, 0x1ff],
+        [0x200, 0xeff], // custom
+        [0xf00, 0xfff], // impl
+    ],
+    "command": [
+        [0x000, 0x07f],
+        [0x080, 0xeff],
+        [0xf00, 0xfff],
+    ],
+    "event": [
+        [0x000, 0x07f],
+        [0x080, 0xeff],
+        [0xf00, 0xfff],
+    ],
+};
+
 export function parseServiceSpecificationMarkdownToJSON(filecontent: string, includes?: jdspec.SMap<jdspec.ServiceSpec>, filename = ""): jdspec.ServiceSpec {
     filecontent = (filecontent || "").replace(/\r/g, "")
     let info: jdspec.ServiceSpec = {
@@ -302,6 +336,12 @@ export function parseServiceSpecificationMarkdownToJSON(filecontent: string, inc
         packetInfo.packed = hasNaturalAlignment(packetInfo) ? undefined : true
         if (packetInfo.packed)
             warn(`you may want to use explicit padding in ${packetInfo.name}`)
+
+        const pid = packetInfo.identifier;
+        const ranges = identifierRanges[packetInfo.kind];
+        if (ranges && !ranges.some(range => range[0] <= pid && pid <= range[1]))
+            error(`${packetInfo.name} identifier 0x${pid.toString(16)} out of range, expected in ${ranges.map(range => `[${range.map(r => `0x${r.toString(16)}`).join(', ')}]`).join(', ')}`)
+
         packetInfo = null
     }
 


### PR DESCRIPTION
is set_register and _get_register special and out of range?

The spec tool now checks for valid ranges of identifiers.

```
process _system.md
..\services\_system.md(26): get_register identifier 0x1000 out of range, expected in [0x0, 0x7f], [0x80, 0xeff], [0xf00, 0xfff]
..\services\_system.md(32): set_register identifier 0x2000 out of range, expected in [0x0, 0x7f], [0x80, 0xeff], [0xf00, 0xfff]
```