### PR TITLE
silent shuts down logging

### DIFF
--- a/dist/c/logger.h
+++ b/dist/c/logger.h
@@ -9,6 +9,7 @@
 #define JD_LOGGER_PRIORITY_LOG 0x1
 #define JD_LOGGER_PRIORITY_WARNING 0x2
 #define JD_LOGGER_PRIORITY_ERROR 0x3
+#define JD_LOGGER_PRIORITY_SILENT 0x4
 
 /**
  * Read-write Priority (uint8_t). Messages with level lower than this won't be emitted. The default setting may vary.

--- a/dist/services.json
+++ b/dist/services.json
@@ -3184,7 +3184,8 @@
           "Debug": 0,
           "Log": 1,
           "Warning": 2,
-          "Error": 3
+          "Error": 3,
+          "Silent": 4
         }
       }
     },
@@ -3292,7 +3293,7 @@
         "packFormat": "s"
       }
     ],
-    "source": "# Logger\n\n    identifier: 0x12dc1fca\n\nA service which can report messages to the bus.\n\n## Registers\n\n    enum Priority : u8 {\n        Debug = 0,\n        Log = 1,\n        Warning = 2,\n        Error = 3\n    }\n    rw min_priority = 1: Priority @ 0x80\n\nMessages with level lower than this won't be emitted. The default setting may vary.\nLoggers should revert this to their default setting if the register has not been\nupdated in 3000ms, and also keep the lowest setting they have seen in the last 1500ms.\nThus, clients should write this register every 1000ms and ignore messages which are\ntoo verbose for them.\n\n## Commands\n\n    report debug @ 0x80 {\n        message: string\n    }\n    report log @ 0x81 {\n        message: string\n    }\n    report warn @ 0x82 {\n        message: string\n    }\n    report error @ 0x83 {\n        message: string\n    }\n\nReport a message.\n"
+    "source": "# Logger\n\n    identifier: 0x12dc1fca\n\nA service which can report messages to the bus.\n\n## Registers\n\n    enum Priority : u8 {\n        Debug = 0,\n        Log = 1,\n        Warning = 2,\n        Error = 3,\n        Silent = 4\n    }\n    rw min_priority = 1: Priority @ 0x80\n\nMessages with level lower than this won't be emitted. The default setting may vary.\nLoggers should revert this to their default setting if the register has not been\nupdated in 3000ms, and also keep the lowest setting they have seen in the last 1500ms.\nThus, clients should write this register every 1000ms and ignore messages which are\ntoo verbose for them.\n\n## Commands\n\n    report debug @ 0x80 {\n        message: string\n    }\n    report log @ 0x81 {\n        message: string\n    }\n    report warn @ 0x82 {\n        message: string\n    }\n    report error @ 0x83 {\n        message: string\n    }\n\nReport a message.\n"
   },
   {
     "name": "Microphone",

--- a/dist/specconstants.sts
+++ b/dist/specconstants.sts
@@ -1156,6 +1156,7 @@ namespace jacdac {
         Log = 0x1,
         Warning = 0x2,
         Error = 0x3,
+        Silent = 0x4,
     }
 
     export const enum LoggerReg {

--- a/dist/specconstants.ts
+++ b/dist/specconstants.ts
@@ -1121,6 +1121,7 @@ export enum LoggerPriority { // uint8_t
     Log = 0x1,
     Warning = 0x2,
     Error = 0x3,
+    Silent = 0x4,
 }
 
 export enum LoggerReg {

--- a/services/logger.md
+++ b/services/logger.md
@@ -10,7 +10,8 @@ A service which can report messages to the bus.
         Debug = 0,
         Log = 1,
         Warning = 2,
-        Error = 3
+        Error = 3,
+        Silent = 4
     }
     rw min_priority = 1: Priority @ 0x80
 


### PR DESCRIPTION
Silent is used as a "no logging" filter in jacdac-ts