### PR TITLE
support for a device service instance name

### DIFF
--- a/services/_base.md
+++ b/services/_base.md
@@ -26,3 +26,6 @@ Notifies that the status code of the service changed.
     const instance_name?: string @ instance_name
 
 A friendly name that describes the role of this service instance in the device.
+It often corresponds to what's printed on the device:
+for example, `A` for button A, or `S0` for servo channel 0.
+Words like `left` should be avoided because of localization issues (unless they are printed on the device).

--- a/services/_base.md
+++ b/services/_base.md
@@ -23,6 +23,6 @@ add this report in frame along with the announce packet.
 
 Notifies that the status code of the service changed.
 
-    const instance_name?: string @ 0x108
+    const instance_name?: string @ instance_name
 
 A friendly name that describes the role of this service instance in the device.

--- a/services/_base.md
+++ b/services/_base.md
@@ -22,3 +22,7 @@ add this report in frame along with the announce packet.
     }
 
 Notifies that the status code of the service changed.
+
+    const instance_name?: string @ 0x108
+
+A friendly name that describes the role of this service instance in the device.

--- a/services/_system.md
+++ b/services/_system.md
@@ -145,6 +145,10 @@ the Jacdac status/error codes. ``vendor_code`` is any vendor specific error code
 state. This report is typically not queried, when a device has an error, it will typically
 add this report in frame along with the announce packet.
 
+    const instanceName?: string @ 0x108
+
+A friendly name that describes the role of this service instance in the device.
+
 ## Events
 
 Events codes are 8-bit and are subdivided as follows:

--- a/services/_system.md
+++ b/services/_system.md
@@ -145,7 +145,7 @@ the Jacdac status/error codes. ``vendor_code`` is any vendor specific error code
 state. This report is typically not queried, when a device has an error, it will typically
 add this report in frame along with the announce packet.
 
-    const instanceName?: string @ 0x108
+    const instance_name?: string @ 0x108
 
 A friendly name that describes the role of this service instance in the device.
 


### PR DESCRIPTION
The micro:bit as a Jacdac device exposes 6 buttons. It's good to have a name for them.