### PR TITLE
Add slider to device map

### DIFF
--- a/devices/microsoft/research/qr-url-device-map.csv
+++ b/devices/microsoft/research/qr-url-device-map.csv
@@ -4,7 +4,7 @@ aaaaab,39,1.1,hub,aka.ms
 aaaaac,37,2.1,RGB LED 8 ring,aka.ms
 aaaaad,29,0.3,Low power micro:bit jacdapter,aka.ms
 aaaaae,10,1.3,PADAUK Button,aka.ms
-aaaaaf,,,,
+aaaaaf,49,1.0,Slider,aka.ms
 aaaaag,,,,
 aaaaah,,,,
 aaaaai,,,,


### PR DESCRIPTION
Adds the slider to the device map so I can give it a QR code. I don't know if the link is active, but if not someone should make it work?

Not yet at version 1.0, but pretty close and (probably) will be 1.0 when it gets sent to fab.
