### PR TITLE
rename 'closed' to 'active' in relay + minor spec fixes

### DIFF
--- a/services/_system.md
+++ b/services/_system.md
@@ -36,13 +36,6 @@ The report format is the same as the format of the register.
 Registers number `N` is set by issuing command `0x2000 | N`, with the format
 the same as the format of the register.
 
-    report event @ 0x01 {
-        event_id: u32
-        event_argument: u32
-    }
-
-Event from sensor or a broadcast service. 
-
     command calibrate @ 0x02 { }
     report { }
 

--- a/services/relay.md
+++ b/services/relay.md
@@ -6,11 +6,17 @@
 
 A switching relay.
 
+The contacts should be labelled `NO` (normally open), `COM` (common), and `NC` (normally closed).
+When relay is energized it connects `NO` and `COM`.
+When relay is not energized it connects `NC` and `COM`.
+Some relays may be missing `NO` or `NC` contacts.
+When relay module is not powered, or is in bootloader mode, it is not energized (connects `NC` and `COM`).
+
 ## Registers
 
-    rw closed: bool @ intensity
+    rw active: bool @ intensity
 
-Indicates whether the relay circuit is currently energized (closed) or not.
+Indicates whether the relay circuit is currently energized or not.
 
     enum Variant: u8 {
         Electromechanical = 1,

--- a/services/switch.md
+++ b/services/switch.md
@@ -28,7 +28,7 @@ Indicates whether the switch is currently active (on).
 
 Describes the type of switch used.
 
-    const auto_off_delay?: u16.16 s @ 0x180
+    const auto_off_delay?: u22.10 s @ 0x180
 
 Specifies the delay without activity to automatically turn off after turning on.
 For example, some light switches in staircases have such a capability.


### PR DESCRIPTION
See #879 

Also, `event` report is no longer used - removing.
Also change `auto_off_delay` encoding to be more reasonable (we don't need sub-ms precision there)
