### PR TITLE
Corrected `requiredDevices` for fwdedu breakout board

### DIFF
--- a/devices/forward-education/climateactionkitv10.json
+++ b/devices/forward-education/climateactionkitv10.json
@@ -34,7 +34,6 @@
     "microbit-educational-foundation-microbitv2"
   ],
   "requiredDevices": [
-    "forward-education-breakoutboardrelaypumpv10",
     "microbit-educational-foundation-microbitv2"
   ]
 }


### PR DESCRIPTION
The kit contains breakout board, is not sold separately